### PR TITLE
Updating deprecated deployment API version

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
This PR updates the deployment API version that was deprecated in Kubernetes API 1.16.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/